### PR TITLE
added version bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node-operator
+TODO
+!vendor/**

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func mainWithError() error {
 		c.GitCommit = gitCommit
 		c.Name = name
 		c.Source = source
+		c.VersionBundles = service.NewVersionBundles()
 
 		newCommand, err = command.New(c)
 		if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -119,6 +119,7 @@ func New(config Config) (*Service, error) {
 		c.GitCommit = config.GitCommit
 		c.Name = config.Name
 		c.Source = config.Source
+		c.VersionBundles = NewVersionBundles()
 
 		versionService, err = version.New(c)
 		if err != nil {

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"time"
+
+	"github.com/giantswarm/versionbundle"
+)
+
+func NewVersionBundles() []versionbundle.Bundle {
+	return []versionbundle.Bundle{
+		{
+			Changelogs: []versionbundle.Changelog{
+				{
+					Component:   "node-operator",
+					Description: "Introduce the first version of the node-operator.",
+					Kind:        versionbundle.KindAdded,
+				},
+			},
+			Components: []versionbundle.Component{
+				{
+					Name:    "node-operator",
+					Version: "0.1.0",
+				},
+			},
+			Dependencies: []versionbundle.Dependency{
+				{
+					Name:    "kubernetes",
+					Version: ">= 1.8.4",
+				},
+			},
+			Deprecated: false,
+			Name:       "node-operator",
+			Time:       time.Date(2018, time.December, 6, 18, 6, 0, 0, time.UTC),
+			Version:    "0.1.0",
+			WIP:        true,
+		},
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2334. 

```
$ ./node-operator version
description: Project node-operator drains Kubernetes nodes on behalf of watched CRDs.
gitcommit: n/a
name: node-operator
source: https://github.com/giantswarm/node-operator
goversion: go1.9.1
os: darwin
arch: amd64
versionbundles:
- changelogs:
  - component: node-operator
    description: Introduce the first version of the node-operator.
    kind: added
  components:
  - name: node-operator
    version: 0.1.0
  dependencies:
  - name: kubernetes
    version: '>= 1.8.4'
  deprecated: false
  name: node-operator
  time: 2018-12-06T18:06:00Z
  version: 0.1.0
  wip: true
```