### PR TITLE
improves reconciliation in error cases 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,7 +75,7 @@
   branch = "master"
   name = "github.com/giantswarm/certs"
   packages = ["."]
-  revision = "162a1130d27d6bbe1ab101059afab985707e46b0"
+  revision = "25f23b0e8cccf531f2f88554d498a9d54d29ca03"
 
 [[projects]]
   branch = "master"
@@ -144,7 +144,7 @@
     "framework/resource/retryresource",
     "informer"
   ]
-  revision = "e785d24fd81b018fa0ebe1fa7874e306a413461a"
+  revision = "1aeeea68c3d286464683f126b4d4c87d885b40ce"
 
 [[projects]]
   branch = "master"
@@ -523,10 +523,10 @@
   version = "v0.9.0"
 
 [[projects]]
+  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  revision = "4fc5987536ef307a24ca299aee7ae301cde3d221"
 
 [[projects]]
   name = "k8s.io/api"
@@ -680,6 +680,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "073022bd4a1a300a6cd1aac5b46eac70b37d0416777e5a0699a5cab94c717ec8"
+  inputs-digest = "c904d13c5a8b64be7749c2e2a2a69c28ec67c47f220fbf4f603811833f02a31a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/service/nodeconfig/v1/resource/node/create.go
+++ b/service/nodeconfig/v1/resource/node/create.go
@@ -43,7 +43,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// logs will surge and we have a chance to try to drain again in case
 			// there are only some weird connection issues to the guest cluster
 			// Kubernetes API.
-			r.logger.LogCtx(ctx, "level", "warning", "message", "cannot find certificates for guest cluster '%s'", key.ClusterID(customObject))
+			r.logger.LogCtx(ctx, "level", "warning", "message", "cannot find certificates for draining guest cluster '%s'", key.ClusterID(customObject))
 			return microerror.Mask(err)
 		} else if err != nil {
 			return microerror.Mask(err)

--- a/service/nodeconfig/v1/resource_set.go
+++ b/service/nodeconfig/v1/resource_set.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"time"
+
 	"github.com/cenkalti/backoff"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/certs"
@@ -40,6 +42,8 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 		c := certs.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
+
+			WatchTimeout: 5 * time.Second,
 		}
 
 		certsSearcher, err = certs.NewSearcher(c)

--- a/vendor/github.com/giantswarm/certs/error.go
+++ b/vendor/github.com/giantswarm/certs/error.go
@@ -4,7 +4,7 @@ import "github.com/giantswarm/microerror"
 
 var executionError = microerror.New("execution error")
 
-func IsExecutionError(err error) bool {
+func IsExecution(err error) bool {
 	return microerror.Cause(err) == executionError
 }
 
@@ -22,12 +22,12 @@ func IsInvalidSecret(err error) bool {
 
 var timeoutError = microerror.New("timeout")
 
-func IsTimeoutError(err error) bool {
+func IsTimeout(err error) bool {
 	return microerror.Cause(err) == timeoutError
 }
 
 var wrongTypeError = microerror.New("wrong type")
 
-func IsWrongTypeError(err error) bool {
+func IsWrongType(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }

--- a/vendor/github.com/giantswarm/operatorkit/framework/finalizer.go
+++ b/vendor/github.com/giantswarm/operatorkit/framework/finalizer.go
@@ -1,0 +1,159 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	finalizerPrefix = "operatorkit.giantswarm.io"
+)
+
+type patchSpec struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+func (f *Framework) addFinalizer(obj interface{}) (stopReconciliation bool, err error) {
+	restClient := f.k8sClient.CoreV1().RESTClient()
+	patch, path, result, err := createAddFinalizerPatch(obj, f.name)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+	if patch == nil {
+		return result, err
+	}
+	p, err := json.Marshal(patch)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+	operation := func() error {
+		res := restClient.Patch(types.JSONPatchType).AbsPath(path).Body(p).Do()
+		if res.Error() != nil {
+			return microerror.Mask(res.Error())
+		}
+		return nil
+	}
+	err = backoff.Retry(operation, f.backOffFactory())
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
+func createAddFinalizerPatch(obj interface{}, operatorName string) (patch []patchSpec, path string, stopReconciliation bool, err error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, "", false, microerror.Mask(err)
+	}
+	if accessor.GetDeletionTimestamp() != nil {
+		return nil, "", true, nil // object has been marked for deletion, we should ignore it.
+	}
+	finalizerName := getFinalizerName(operatorName)
+	if containsFinalizer(accessor.GetFinalizers(), finalizerName) {
+		return nil, "", false, nil // object already has the finalizer.
+	}
+	patch = []patchSpec{}
+	if len(accessor.GetFinalizers()) == 0 {
+		createPatch := patchSpec{
+			Op:    "add",
+			Value: []string{},
+			Path:  "/metadata/finalizers",
+		}
+		patch = append(patch, createPatch)
+	}
+
+	addPatch := patchSpec{
+		Op:    "add",
+		Value: finalizerName,
+		Path:  "/metadata/finalizers/-",
+	}
+	patch = append(patch, addPatch)
+	return patch, accessor.GetSelfLink(), true, nil
+}
+
+func createRemoveFinalizerPatch(obj interface{}, operatorName string) (patch []patchSpec, path string, err error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, "", microerror.Mask(err)
+	}
+	finalizerName := getFinalizerName(operatorName)
+	if !containsFinalizer(accessor.GetFinalizers(), finalizerName) {
+		// object has not finalizer set, this could have two reasons:
+		// 1. We are migrating and an old object never got reconciled before deletion.
+		// 2. The operator wasn't running and our first interaction with the object
+		// is its deletion.
+		// Both cases should not be harmful in general, so we ignore it.
+		return nil, "", nil
+	}
+	patch = []patchSpec{}
+	deletePatch := patchSpec{
+		Op:    "replace",
+		Value: removeFinalizer(accessor.GetFinalizers(), finalizerName),
+		Path:  "/metadata/finalizers",
+	}
+	patch = append(patch, deletePatch)
+	return patch, accessor.GetSelfLink(), nil
+}
+
+func (f *Framework) removeFinalizer(ctx context.Context, obj interface{}) error {
+	restClient := f.k8sClient.CoreV1().RESTClient()
+	patch, path, err := createRemoveFinalizerPatch(obj, f.name)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if patch == nil {
+		f.logger.LogCtx(ctx, "function", "removeFinalizer", "level", "warning", "message", "object is missing a finalizer")
+		return nil
+	}
+	p, err := json.Marshal(patch)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	operation := func() error {
+		res := restClient.Patch(types.JSONPatchType).AbsPath(path).Body(p).Do()
+		if errors.IsNotFound(res.Error()) {
+			return nil // the object is already gone, nothing to do.
+		} else if res.Error() != nil {
+			return microerror.Mask(res.Error())
+		}
+		return nil
+	}
+	err = backoff.Retry(operation, f.backOffFactory())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func containsFinalizer(finalizers []string, finalizer string) bool {
+	for _, f := range finalizers {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func getFinalizerName(name string) string {
+	return fmt.Sprintf("%s/%s", finalizerPrefix, name)
+}
+
+func removeFinalizer(finalizers []string, finalizer string) []string {
+	for i, f := range finalizers {
+		if f == finalizer {
+			finalizers = append(finalizers[:i], finalizers[i+1:]...)
+			break
+		}
+	}
+	return finalizers
+}

--- a/vendor/github.com/giantswarm/operatorkit/framework/framework.go
+++ b/vendor/github.com/giantswarm/operatorkit/framework/framework.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/framework/context/reconciliationcanceledcontext"
@@ -42,14 +43,20 @@ type Config struct {
 	// and different resources can be executed depending on the runtime object
 	// being reconciled.
 	ResourceRouter *ResourceRouter
+	K8sClient      kubernetes.Interface
 
 	BackOffFactory func() backoff.BackOff
+	// Name is the name which the framework uses on finalizers for resources.
+	// The name used should be unique in the kubernetes cluster, to ensure that
+	// two operators which handle the same resource add two distinct finalizers.
+	Name string
 }
 
 type Framework struct {
 	crd            *apiextensionsv1beta1.CustomResourceDefinition
 	crdClient      *k8scrdclient.CRDClient
 	informer       informer.Interface
+	k8sClient      kubernetes.Interface
 	logger         micrologger.Logger
 	resourceRouter *ResourceRouter
 
@@ -57,6 +64,7 @@ type Framework struct {
 	mutex    sync.Mutex
 
 	backOffFactory func() backoff.BackOff
+	name           string
 }
 
 // New creates a new configured operator framework.
@@ -66,6 +74,9 @@ func New(config Config) (*Framework, error) {
 	}
 	if config.Informer == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Informer must not be empty")
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
@@ -77,11 +88,15 @@ func New(config Config) (*Framework, error) {
 	if config.BackOffFactory == nil {
 		config.BackOffFactory = DefaultBackOffFactory()
 	}
+	if config.Name == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Name must not be empty")
+	}
 
 	f := &Framework{
 		crd:            config.CRD,
 		crdClient:      config.CRDClient,
 		informer:       config.Informer,
+		k8sClient:      config.K8sClient,
 		logger:         config.Logger,
 		resourceRouter: config.ResourceRouter,
 
@@ -89,6 +104,7 @@ func New(config Config) (*Framework, error) {
 		mutex:    sync.Mutex{},
 
 		backOffFactory: config.BackOffFactory,
+		name:           config.Name,
 	}
 
 	return f, nil
@@ -150,6 +166,12 @@ func (f *Framework) DeleteFunc(obj interface{}) {
 		f.logger.LogCtx(ctx, "event", "delete", "function", "DeleteFunc", "level", "error", "message", "stop framework reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
 		return
 	}
+
+	err = f.removeFinalizer(ctx, obj)
+	if err != nil {
+		f.logger.LogCtx(ctx, "event", "delete", "function", "DeleteFunc", "level", "error", "message", "stop framework reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
+		return
+	}
 }
 
 // ProcessEvents takes the event channels created by the operatorkit informer
@@ -196,6 +218,18 @@ func (f *Framework) UpdateFunc(oldObj, newObj interface{}) {
 	// run into race conditions.
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
+
+	ok, err := f.addFinalizer(obj)
+	if err != nil {
+		f.logger.Log("event", "update", "function", "UpdateFunc", "level", "error", "message", "stop framework reconciliation due to error", "stack", fmt.Sprintf("%#v", err))
+		return
+	}
+	if ok {
+		// A finalizer was added, this causes a new update event, so we stop
+		// reconciling here and will pick up the new event.
+		f.logger.Log("event", "update", "function", "UpdateFunc", "level", "debug", "message", "stop framework reconciliation due to finalizer added")
+		return
+	}
 
 	resourceSet, err := f.resourceRouter.ResourceSet(obj)
 	if IsNoResourceSet(err) {

--- a/vendor/gopkg.in/yaml.v2/README.md
+++ b/vendor/gopkg.in/yaml.v2/README.md
@@ -48,8 +48,6 @@ The yaml package is licensed under the Apache License 2.0. Please see the LICENS
 Example
 -------
 
-Some more examples can be found in the "examples" folder.
-
 ```Go
 package main
 

--- a/vendor/gopkg.in/yaml.v2/apic.go
+++ b/vendor/gopkg.in/yaml.v2/apic.go
@@ -468,7 +468,7 @@ func yaml_event_delete(event *yaml_event_t) {
 //    } context
 //    tag_directive *yaml_tag_directive_t
 //
-//    context.error = YAML_NO_ERROR // Eliminate a compliler warning.
+//    context.error = YAML_NO_ERROR // Eliminate a compiler warning.
 //
 //    assert(document) // Non-NULL document object is expected.
 //

--- a/vendor/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/gopkg.in/yaml.v2/emitterc.go
@@ -843,7 +843,7 @@ func yaml_emitter_select_scalar_style(emitter *yaml_emitter_t, event *yaml_event
 	return true
 }
 
-// Write an achor.
+// Write an anchor.
 func yaml_emitter_process_anchor(emitter *yaml_emitter_t) bool {
 	if emitter.anchor_data.anchor == nil {
 		return true

--- a/vendor/gopkg.in/yaml.v2/encode.go
+++ b/vendor/gopkg.in/yaml.v2/encode.go
@@ -131,7 +131,7 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		} else {
 			e.structv(tag, in)
 		}
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		if in.Type().Elem() == mapItemType {
 			e.itemsv(tag, in)
 		} else {
@@ -328,10 +328,8 @@ func (e *encoder) uintv(tag string, in reflect.Value) {
 
 func (e *encoder) timev(tag string, in reflect.Value) {
 	t := in.Interface().(time.Time)
-	if tag == "" {
-		tag = yaml_TIMESTAMP_TAG
-	}
-	e.emitScalar(t.Format(time.RFC3339Nano), "", tag, yaml_PLAIN_SCALAR_STYLE)
+	s := t.Format(time.RFC3339Nano)
+	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
 }
 
 func (e *encoder) floatv(tag string, in reflect.Value) {

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -92,6 +92,19 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 		switch tag {
 		case "", rtag, yaml_STR_TAG, yaml_BINARY_TAG:
 			return
+		case yaml_FLOAT_TAG:
+			if rtag == yaml_INT_TAG {
+				switch v := out.(type) {
+				case int64:
+					rtag = yaml_FLOAT_TAG
+					out = float64(v)
+					return
+				case int:
+					rtag = yaml_FLOAT_TAG
+					out = float64(v)
+					return
+				}
+			}
 		}
 		failf("cannot decode %s `%s` as a %s", shortTag(rtag), in, shortTag(tag))
 	}()
@@ -167,12 +180,12 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					return yaml_INT_TAG, uintv
 				}
 			} else if strings.HasPrefix(plain, "-0b") {
-				intv, err := strconv.ParseInt(plain[3:], 2, 64)
+				intv, err := strconv.ParseInt("-" + plain[3:], 2, 64)
 				if err == nil {
-					if intv == int64(int(intv)) {
-						return yaml_INT_TAG, -int(intv)
+					if true || intv == int64(int(intv)) {
+						return yaml_INT_TAG, int(intv)
 					} else {
-						return yaml_INT_TAG, -intv
+						return yaml_INT_TAG, intv
 					}
 				}
 			}
@@ -211,10 +224,10 @@ func encodeBase64(s string) string {
 // This is a subset of the formats allowed by the regular expression
 // defined at http://yaml.org/type/timestamp.html.
 var allowedTimestampFormats = []string{
-	"2006-1-2T15:4:5Z07:00",
-	"2006-1-2t15:4:5Z07:00", // RFC3339 with lower-case "t".
-	"2006-1-2 15:4:5",       // space separated with no time zone
-	"2006-1-2",              // date only
+	"2006-1-2T15:4:5.999999999Z07:00", // RCF3339Nano with short date fields.
+	"2006-1-2t15:4:5.999999999Z07:00", // RFC3339Nano with short date fields and lower-case "t".
+	"2006-1-2 15:4:5.999999999",       // space separated with no time zone
+	"2006-1-2",                        // date only
 	// Notable exception: time.Parse cannot handle: "2001-12-14 21:59:43.10 -5"
 	// from the set of examples.
 }

--- a/vendor/gopkg.in/yaml.v2/sorter.go
+++ b/vendor/gopkg.in/yaml.v2/sorter.go
@@ -51,6 +51,15 @@ func (l keyList) Less(i, j int) bool {
 		}
 		var ai, bi int
 		var an, bn int64
+		if ar[i] == '0' || br[i] == '0' {
+			for j := i-1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
+				if ar[j] != '0' {
+					an = 1
+					bn = 1
+					break
+				}
+			}
+		}
 		for ai = i; ai < len(ar) && unicode.IsDigit(ar[ai]); ai++ {
 			an = an*10 + int64(ar[ai]-'0')
 		}

--- a/vendor/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/gopkg.in/yaml.v2/yaml.go
@@ -157,8 +157,8 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 // of the generated document will reflect the structure of the value itself.
 // Maps and pointers (to struct, string, int, etc) are accepted as the in value.
 //
-// Struct fields are only unmarshalled if they are exported (have an upper case
-// first letter), and are unmarshalled using the field name lowercased as the
+// Struct fields are only marshalled if they are exported (have an upper case
+// first letter), and are marshalled using the field name lowercased as the
 // default key. Custom keys may be defined via the "yaml" name in the field
 // tag: the content preceding the first comma is used as the key, and the
 // following comma-separated options are used to tweak the marshalling process.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2879. With this the node-operator should be better off already because it can take care about resources a lot quicker because it fails faster. We also get a specific kind of log message we can alert on. 