### PR TITLE
updates to final state only if CR does not have final state

### DIFF
--- a/service/controller/v1/resource/node/create.go
+++ b/service/controller/v1/resource/node/create.go
@@ -156,7 +156,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running system workloads")
 	}
 
-	{
+	if !customObject.Status.HasFinalCondition() {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "setting node config status of guest cluster node to final state")
 
 		customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())


### PR DESCRIPTION
I noticed there is an endless loop happening because the operator updates the CR which triggers an update event and the operator gets caught in a loop. 