### PR TITLE
Use release time to force pods always deploys.

### DIFF
--- a/helm/node-operator-chart/templates/deployment.yaml
+++ b/helm/node-operator-chart/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        releasetime: {{ $.Release.Time }}
       labels:
         app: node-operator
     spec:


### PR DESCRIPTION
In order to make Helm always deploy PODs on deploy event, add release
time to deployment annotation. This changes on every deploy event which
changes deployment descriptor and therefore triggers Helm.

Towards giantswarm/giantswarm#3395