### PR TITLE
fixes rbac rules

### DIFF
--- a/helm/node-operator-chart/templates/rbac.yaml
+++ b/helm/node-operator-chart/templates/rbac.yaml
@@ -20,6 +20,7 @@ rules:
       - get
       - list
       - update
+      - patch
       - watch
   # The node-operator watches DrainerConfig CRs and updates their status. It
   # must not be allowed to create these CRs nor delete them. This responsibility
@@ -32,6 +33,7 @@ rules:
       - get
       - list
       - update
+      - patch
       - watch
   # The node-operator watches secrets in order to create Kubernetes clients for
   # being able to access guest clusters to drain its nodes. It must not be


### PR DESCRIPTION
With the last changes I made on the drainer config the RBAC rules got screwed and the patch verb was not allowed. I do not really understand why this is necessary because our code does not seem to call any patch on `NodeConfig` CRs but this fixes the issue we have with draining right now, which is also the reason why the e2e tests in the `aws-operator` fail at the moment. 