### PR TITLE
Revert "removes node config support"

### DIFF
--- a/service/controller/node.go
+++ b/service/controller/node.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/client/k8scrdclient"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/informer"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/node-operator/service/controller/v1"
+)
+
+type NodeConfig struct {
+	G8sClient    versioned.Interface
+	K8sClient    kubernetes.Interface
+	K8sExtClient apiextensionsclient.Interface
+	Logger       micrologger.Logger
+
+	ProjectName string
+}
+
+type Node struct {
+	*controller.Controller
+}
+
+func NewNode(config NodeConfig) (*Node, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+
+	var err error
+
+	var crdClient *k8scrdclient.CRDClient
+	{
+		c := k8scrdclient.Config{
+			K8sExtClient: config.K8sExtClient,
+			Logger:       config.Logger,
+		}
+
+		crdClient, err = k8scrdclient.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var newInformer *informer.Informer
+	{
+		c := informer.Config{
+			Logger:  config.Logger,
+			Watcher: config.G8sClient.CoreV1alpha1().NodeConfigs(""),
+
+			RateWait:     informer.DefaultRateWait,
+			ResyncPeriod: informer.DefaultResyncPeriod,
+		}
+
+		newInformer, err = informer.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var v1ResourceSet *controller.ResourceSet
+	{
+		c := v1.ResourceSetConfig{}
+
+		c.G8sClient = config.G8sClient
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		c.HandledVersionBundles = []string{
+			"0.1.0",
+		}
+		c.ProjectName = config.ProjectName
+
+		v1ResourceSet, err = v1.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var resourceRouter *controller.ResourceRouter
+	{
+		c := controller.ResourceRouterConfig{
+			Logger: config.Logger,
+
+			ResourceSets: []*controller.ResourceSet{
+				v1ResourceSet,
+			},
+		}
+
+		resourceRouter, err = controller.NewResourceRouter(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var operatorkitController *controller.Controller
+	{
+		c := controller.Config{
+			CRD:            v1alpha1.NewNodeConfigCRD(),
+			CRDClient:      crdClient,
+			Informer:       newInformer,
+			Logger:         config.Logger,
+			ResourceRouter: resourceRouter,
+			RESTClient:     config.G8sClient.CoreV1alpha1().RESTClient(),
+
+			Name: config.ProjectName,
+		}
+
+		operatorkitController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	n := &Node{
+		Controller: operatorkitController,
+	}
+
+	return n, nil
+}

--- a/service/controller/v1/resource/node/create.go
+++ b/service/controller/v1/resource/node/create.go
@@ -1,0 +1,155 @@
+package node
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/node-operator/service/controller/v1/key"
+)
+
+const (
+	// UnschedulablePatch is the JSON patch structure being applied to nodes using
+	// a strategic merge patch in order to drain them.
+	UnschedulablePatch = `{"spec":{"unschedulable":true}}`
+)
+
+// EnsureCreated represents the node resource implementation to manage on demand
+// node draining for guest clusters.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+
+	if customObject.Status.HasFinalCondition() {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "node config status already has final state", "clusterID", clusterID)
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+
+		return nil
+	}
+
+	k8sClient, err := r.guestCluster.NewK8sClient(ctx, key.ClusterID(customObject), key.ClusterAPIEndpoint(customObject))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoning guest cluster node", "clusterID", clusterID)
+
+		n := key.NodeName(customObject)
+		t := types.StrategicMergePatchType
+		p := []byte(UnschedulablePatch)
+
+		_, err := k8sClient.CoreV1().Nodes().Patch(n, t, p)
+		if apierrors.IsNotFound(err) {
+			// It might happen the node we want to drain got already removed. This
+			// might even be due to human intervention. In case we cannot find the
+			// node we assume the draining was successful and set the node config
+			// status accordingly.
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found", "clusterID", clusterID)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "setting node config status of guest cluster node to final state", "clusterID", clusterID)
+
+			customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())
+
+			_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(customObject.GetNamespace()).Update(&customObject)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "set node config status of guest cluster node to final state", "clusterID", clusterID)
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoned guest cluster node", "clusterID", clusterID)
+	}
+
+	var customPods []v1.Pod
+	var systemPods []v1.Pod
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for all pods running on the guest cluster node", "clusterID", clusterID)
+
+		fieldSelector := fields.SelectorFromSet(fields.Set{
+			"spec.nodeName": key.NodeName(customObject),
+		})
+		listOptions := apismetav1.ListOptions{
+			FieldSelector: fieldSelector.String(),
+		}
+		podList, err := k8sClient.CoreV1().Pods(v1.NamespaceAll).List(listOptions)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, p := range podList.Items {
+			if p.GetNamespace() == "kube-system" {
+				systemPods = append(systemPods, p)
+			} else {
+				customPods = append(customPods, p)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running custom workloads", len(customPods)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running system workloads", len(systemPods)), "clusterID", clusterID)
+	}
+
+	if len(customPods) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running custom workloads", "clusterID", clusterID)
+
+		for _, p := range customPods {
+			err := k8sClient.CoreV1().Pods(p.GetNamespace()).Delete(p.GetName(), &apismetav1.DeleteOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running custom workloads", "clusterID", clusterID)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running custom workloads", "clusterID", clusterID)
+	}
+
+	if len(systemPods) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running system workloads", "clusterID", clusterID)
+
+		for _, p := range systemPods {
+			err := k8sClient.CoreV1().Pods(p.GetNamespace()).Delete(p.GetName(), &apismetav1.DeleteOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running system workloads", "clusterID", clusterID)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running system workloads", "clusterID", clusterID)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting node config status of node in guest cluster '%s' to final state", key.ClusterID(customObject)), "clusterID", clusterID)
+
+		customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())
+
+		_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(customObject.GetNamespace()).Update(&customObject)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set node config status of node in guest cluster '%s' to final state", key.ClusterID(customObject)), "clusterID", clusterID)
+	}
+
+	return nil
+}

--- a/service/controller/v1/resource/node/delete.go
+++ b/service/controller/v1/resource/node/delete.go
@@ -1,0 +1,11 @@
+package node
+
+import (
+	"context"
+)
+
+// EnsureDeleted is a noop, because the node resource implementation is not
+// interested in delete events of the nodeconfigs.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v1/resource/node/error.go
+++ b/service/controller/v1/resource/node/error.go
@@ -1,0 +1,10 @@
+package node
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v1/resource/node/resource.go
+++ b/service/controller/v1/resource/node/resource.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/guestcluster"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "nodev1"
+)
+
+type Config struct {
+	GuestCluster guestcluster.Interface
+	G8sClient    versioned.Interface
+	Logger       micrologger.Logger
+}
+
+type Resource struct {
+	guestCluster guestcluster.Interface
+	g8sClient    versioned.Interface
+	logger       micrologger.Logger
+}
+
+func New(c Config) (*Resource, error) {
+	if c.GuestCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GuestCluster must not be empty", c)
+	}
+	if c.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", c)
+	}
+	if c.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", c)
+	}
+
+	r := &Resource{
+		guestCluster: c.GuestCluster,
+		g8sClient:    c.G8sClient,
+		logger:       c.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v1/resource_set.go
+++ b/service/controller/v1/resource_set.go
@@ -1,0 +1,134 @@
+package v1
+
+import (
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/guestcluster"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/node-operator/service/controller/v1/key"
+	"github.com/giantswarm/node-operator/service/controller/v1/resource/node"
+)
+
+const (
+	ResourceRetries uint64 = 3
+)
+
+type ResourceSetConfig struct {
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+
+	HandledVersionBundles []string
+	ProjectName           string
+}
+
+func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	var certsSearcher certs.Interface
+	{
+		c := certs.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			WatchTimeout: 5 * time.Second,
+		}
+
+		certsSearcher, err = certs.NewSearcher(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var guestCluster guestcluster.Interface
+	{
+		c := guestcluster.Config{
+			CertsSearcher: certsSearcher,
+			Logger:        config.Logger,
+
+			CertID: certs.NodeOperatorCert,
+		}
+
+		guestCluster, err = guestcluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var nodeResource controller.Resource
+	{
+		c := node.Config{
+			GuestCluster: guestCluster,
+			G8sClient:    config.G8sClient,
+			Logger:       config.Logger,
+		}
+
+		nodeResource, err = node.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		nodeResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		customObject, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(customObject) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -35,14 +35,15 @@ type Service struct {
 
 	bootOnce          sync.Once
 	drainerController *controller.Drainer
+	nodeController    *controller.Node
 }
 
 func New(config Config) (*Service, error) {
 	if config.Flag == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Flag must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "config.Flag must not be empty")
 	}
 	if config.Viper == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Viper must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "config.Viper must not be empty")
 	}
 
 	var err error
@@ -112,6 +113,23 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var nodeController *controller.Node
+	{
+		c := controller.NodeConfig{
+			G8sClient:    g8sClient,
+			K8sClient:    k8sClient,
+			K8sExtClient: k8sExtClient,
+			Logger:       config.Logger,
+
+			ProjectName: config.Name,
+		}
+
+		nodeController, err = controller.NewNode(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var versionService *version.Service
 	{
 		c := version.DefaultConfig()
@@ -134,6 +152,7 @@ func New(config Config) (*Service, error) {
 
 		bootOnce:          sync.Once{},
 		drainerController: drainerController,
+		nodeController:    nodeController,
 	}
 
 	return newService, nil
@@ -142,5 +161,6 @@ func New(config Config) (*Service, error) {
 func (s *Service) Boot() {
 	s.bootOnce.Do(func() {
 		go s.drainerController.Boot()
+		go s.nodeController.Boot()
 	})
 }


### PR DESCRIPTION
Reverts giantswarm/node-operator#53. This wasn't a smart move here. We have to keep the `NodeConfig` support for a while until no clusters rely on them anymore. Only the latest versions run on `DrainerConfig` CRs. 