### PR TITLE
Instead of repetitive log values, use initCtxFunc for clusterID logging

### DIFF
--- a/service/controller/v1/resource/drainer/create.go
+++ b/service/controller/v1/resource/drainer/create.go
@@ -31,18 +31,16 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	clusterID := key.ClusterIDFromDrainerConfig(drainerConfig)
-
 	if drainerConfig.Status.HasDrainedCondition() {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config status has drained condition", "clusterID", clusterID)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config status has drained condition")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
 
 		return nil
 	}
 
 	if drainerConfig.Status.HasTimeoutCondition() {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config status has timeout condition", "clusterID", clusterID)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config status has timeout condition")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
 
 		return nil
 	}
@@ -77,7 +75,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoning guest cluster node", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoning guest cluster node")
 
 		n := key.NodeNameFromDrainerConfig(drainerConfig)
 		t := types.StrategicMergePatchType
@@ -90,8 +88,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// node we assume the draining was successful and set the drainer config
 			// status accordingly.
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found", "clusterID", clusterID)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "setting drainer config status of guest cluster node to drained condition", "clusterID", clusterID)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "setting drainer config status of guest cluster node to drained condition")
 
 			drainerConfig.Status.Conditions = append(drainerConfig.Status.Conditions, drainerConfig.Status.NewDrainedCondition())
 
@@ -100,21 +98,21 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "set drainer config status of guest cluster node to drained condition", "clusterID", clusterID)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "set drainer config status of guest cluster node to drained condition")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
 
 			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoned guest cluster node", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoned guest cluster node")
 	}
 
 	var customPods []v1.Pod
 	var systemPods []v1.Pod
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for all pods running on the guest cluster node", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for all pods running on the guest cluster node")
 
 		fieldSelector := fields.SelectorFromSet(fields.Set{
 			"spec.nodeName": key.NodeNameFromDrainerConfig(drainerConfig),
@@ -135,12 +133,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running custom workloads", len(customPods)), "clusterID", clusterID)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running system workloads", len(systemPods)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running custom workloads", len(customPods)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running system workloads", len(systemPods)))
 	}
 
 	if len(customPods) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running custom workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running custom workloads")
 
 		for _, p := range customPods {
 			err := k8sClient.CoreV1().Pods(p.GetNamespace()).Delete(p.GetName(), &apismetav1.DeleteOptions{})
@@ -149,13 +147,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running custom workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running custom workloads")
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running custom workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running custom workloads")
 	}
 
 	if len(systemPods) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running system workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running system workloads")
 
 		for _, p := range systemPods {
 			err := k8sClient.CoreV1().Pods(p.GetNamespace()).Delete(p.GetName(), &apismetav1.DeleteOptions{})
@@ -164,9 +162,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running system workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running system workloads")
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running system workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running system workloads")
 	}
 
 	{
@@ -183,7 +181,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting drainer config status of node in guest cluster '%s' to drained condition", key.ClusterIDFromDrainerConfig(drainerConfig)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting drainer config status of node in guest cluster '%s' to drained condition", key.ClusterIDFromDrainerConfig(drainerConfig)))
 
 		drainerConfig.Status.Conditions = append(drainerConfig.Status.Conditions, drainerConfig.Status.NewDrainedCondition())
 
@@ -192,7 +190,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set drainer config status of node in guest cluster '%s' to drained condition", key.ClusterIDFromDrainerConfig(drainerConfig)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set drainer config status of node in guest cluster '%s' to drained condition", key.ClusterIDFromDrainerConfig(drainerConfig)))
 	}
 
 	return nil

--- a/service/controller/v1/resource/node/create.go
+++ b/service/controller/v1/resource/node/create.go
@@ -29,12 +29,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	clusterID := key.ClusterID(customObject)
-
 	if customObject.Status.HasFinalCondition() {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "node config status already has final state", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "node config status already has final state")
 		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
 
 		return nil
 	}
@@ -45,7 +43,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoning guest cluster node", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoning guest cluster node")
 
 		n := key.NodeName(customObject)
 		t := types.StrategicMergePatchType
@@ -58,8 +56,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// node we assume the draining was successful and set the node config
 			// status accordingly.
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found", "clusterID", clusterID)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "setting node config status of guest cluster node to final state", "clusterID", clusterID)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "setting node config status of guest cluster node to final state")
 
 			customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())
 
@@ -68,22 +66,22 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			r.logger.LogCtx(ctx, "level", "debug", "message", "set node config status of guest cluster node to final state", "clusterID", clusterID)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "set node config status of guest cluster node to final state")
 			resourcecanceledcontext.SetCanceled(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object", "clusterID", clusterID)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
 
 			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoned guest cluster node", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cordoned guest cluster node")
 	}
 
 	var customPods []v1.Pod
 	var systemPods []v1.Pod
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for all pods running on the guest cluster node", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for all pods running on the guest cluster node")
 
 		fieldSelector := fields.SelectorFromSet(fields.Set{
 			"spec.nodeName": key.NodeName(customObject),
@@ -104,12 +102,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running custom workloads", len(customPods)), "clusterID", clusterID)
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running system workloads", len(systemPods)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running custom workloads", len(customPods)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d pods running system workloads", len(systemPods)))
 	}
 
 	if len(customPods) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running custom workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running custom workloads")
 
 		for _, p := range customPods {
 			err := k8sClient.CoreV1().Pods(p.GetNamespace()).Delete(p.GetName(), &apismetav1.DeleteOptions{})
@@ -118,13 +116,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running custom workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running custom workloads")
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running custom workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running custom workloads")
 	}
 
 	if len(systemPods) > 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running system workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting all pods running system workloads")
 
 		for _, p := range systemPods {
 			err := k8sClient.CoreV1().Pods(p.GetNamespace()).Delete(p.GetName(), &apismetav1.DeleteOptions{})
@@ -133,13 +131,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			}
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running system workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted all pods running system workloads")
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running system workloads", "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no pods to be deleted running system workloads")
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting node config status of node in guest cluster '%s' to final state", key.ClusterID(customObject)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting node config status of node in guest cluster '%s' to final state", key.ClusterID(customObject)))
 
 		customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())
 
@@ -148,7 +146,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set node config status of node in guest cluster '%s' to final state", key.ClusterID(customObject)), "clusterID", clusterID)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("set node config status of node in guest cluster '%s' to final state", key.ClusterID(customObject)))
 	}
 
 	return nil


### PR DESCRIPTION
When initializing LoggerMeta in initCtxFunc, common values can be added
to log context once instead of adding key-vals to every log message.

While there, also logged nodename when it was available.