### PR TITLE
delete nodes from guest API when drainer config gets deleted

### DIFF
--- a/service/controller/v1/resource/drainer/delete.go
+++ b/service/controller/v1/resource/drainer/delete.go
@@ -2,10 +2,54 @@ package drainer
 
 import (
 	"context"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/node-operator/service/controller/v1/key"
 )
 
-// EnsureDeleted is a noop, because the node resource implementation is not
-// interested in delete events of the nodeconfigs.
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	drainerConfig, err := key.ToDrainerConfig(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var k8sClient kubernetes.Interface
+	{
+		i := key.ClusterIDFromDrainerConfig(drainerConfig)
+		e := key.ClusterEndpointFromDrainerConfig(drainerConfig)
+		k8sClient, err = r.guestCluster.NewK8sClient(ctx, i, e)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting guest cluster node from Kubernetes API")
+
+		n := key.NodeNameFromDrainerConfig(drainerConfig)
+		o := &metav1.DeleteOptions{}
+		err := k8sClient.CoreV1().Nodes().Delete(n, o)
+		if guest.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster API is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted guest cluster node from Kubernetes API")
+	}
+
 	return nil
 }

--- a/service/controller/v1/resource/drainer/delete.go
+++ b/service/controller/v1/resource/drainer/delete.go
@@ -35,11 +35,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		o := &metav1.DeleteOptions{}
 		err := k8sClient.CoreV1().Nodes().Delete(n, o)
 		if guest.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not delete guest cluster node from Kubernetes API")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster API is not available")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 			return nil
 		} else if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not delete guest cluster node from Kubernetes API")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster node not found")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 


### PR DESCRIPTION
Still have to test this with the draining support in Azure. Right now there is a dead lock because we use the node information in the API for draining and updating further. After draining we remove the nodes and the information we need to do further updates is missing. So we sit in a deadlock. To overcome this problem and to improve the lifecycle of the drainer config and its associated actions we delete the nodes from the guest API with the deletion of the drainer config. 