### PR TITLE
Tighten RBAC rules for DrainerConfig & NodeConfig

### DIFF
--- a/helm/node-operator-chart/templates/rbac.yaml
+++ b/helm/node-operator-chart/templates/rbac.yaml
@@ -19,8 +19,6 @@ rules:
     verbs:
       - get
       - list
-      - update
-      - patch
       - watch
   - apiGroups:
       - core.giantswarm.io
@@ -40,8 +38,6 @@ rules:
     verbs:
       - get
       - list
-      - update
-      - patch
       - watch
   - apiGroups:
       - core.giantswarm.io

--- a/service/controller/v1/resource/node/create.go
+++ b/service/controller/v1/resource/node/create.go
@@ -67,7 +67,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 			customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())
 
-			_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(customObject.GetNamespace()).Update(&customObject)
+			_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(customObject.GetNamespace()).UpdateStatus(&customObject)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -147,7 +147,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		customObject.Status.Conditions = append(customObject.Status.Conditions, customObject.Status.NewFinalCondition())
 
-		_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(customObject.GetNamespace()).Update(&customObject)
+		_, err := r.g8sClient.CoreV1alpha1().NodeConfigs(customObject.GetNamespace()).UpdateStatus(&customObject)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
When CRs Status section is updated with UpdateStatus() the RBAC rules
for reconciled CR can be then tightened to read-only operations get,
list and watch. Only CR/Status is allowed to be Patched or Updated.

Node resource had two pending Update -> UpdateStatus() changes that are
taken care of in this commit. These were towards
https://github.com/giantswarm/apiextensions/pull/168