### PR TITLE
Configure default image registry domain

### DIFF
--- a/helm/node-operator-chart/values.yaml
+++ b/helm/node-operator-chart/values.yaml
@@ -1,6 +1,10 @@
 image:
   repository: "giantswarm/node-operator"
   tag: "[[ .SHA ]]"
+Installation:
+  V1:
+    Registry:
+      Domain: quay.io
 pod:
   user:
     id: 1000


### PR DESCRIPTION
While testing https://github.com/giantswarm/azure-operator/pull/603 tests started failing with
```
{"caller":"github.com/giantswarm/azure-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:364","level":"debug","message":"err string: `rpc error: code = Unknown desc = render error in \"node-operator-chart/templates/deployment.yaml\": template: node-operator-chart/templates/deployment.yaml:33:26: executing \"node-operator-chart/templates/deployment.yaml\" at \u003c.Values.Installation.V1.Registry.Domain\u003e: nil pointer evaluating interface {}.Domain`","time":"2019-12-12T10:06:53.957511+00:00"}
{"caller":"github.com/giantswarm/azure-operator/vendor/github.com/giantswarm/backoff/notifier.go:13","level":"warning","message":"retrying backoff in '5s' due to error","stack":"[{/go/src/github.com/giantswarm/azure-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:365: } {rpc error: code = Unknown desc = render error in \"node-operator-chart/templates/deployment.yaml\": template: node-operator-chart/templates/deployment.yaml:33:26: executing \"node-operator-chart/templates/deployment.yaml\" at \u003c.Values.Installation.V1.Registry.Domain\u003e: nil pointer evaluating interface {}.Domain}]","time":"2019-12-12T10:06:53.957616+00:00"}
```

Root cause is that https://github.com/giantswarm/node-operator/pull/102 introduced a new configuration property `Installation.V1.Registry.Domain`, replacing old one `image.registry` which had default `quay.io` value with new one without default value configured, and without making it configurable in https://github.com/giantswarm/e2etemplates/blob/master/pkg/chartvalues/node_operator.go, breaking all e2e tests using node-operator.

This PR sets default value for `Installation.V1.Registry.Domain` to `quay.io`.