### PR TITLE
Ignore cert-exporter-deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore `cert-exporter-deployment.`
+
 ## [1.4.1] - 2022-10-10
 
 ### Fixed

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -47,6 +47,13 @@ func IsDaemonSetPod(pod v1.Pod) bool {
 	return r
 }
 
+func IsDeploymentPod(podName string) bool {
+	r := false
+	r = r || strings.HasPrefix(podName, "cert-exporter-deployment")
+
+	return r
+}
+
 func IsEvictedPod(pod v1.Pod) bool {
 	return pod.Status.Reason == "Evicted"
 }

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -167,6 +167,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				// we are aligning here with community as 'kubectl drain' also ignore them
 				continue
 			}
+			if key.IsDeploymentPod(p.Name) {
+				// ignore special deployments (cert-exporter-deployment)
+				continue
+			}
 			if key.IsEvictedPod(p) {
 				// we don't need to care about already evicted pods
 				continue


### PR DESCRIPTION
Quickfix to unblock upgrading AWS release v18.1.0

`cert-exporter-deployment` blocks drained master nodes from being deleted

```
{
    "caller": "github.com/giantswarm/node-operator/service/controller/resource/drainer/create.go:223",
    "controller": "node-operator",
    "event": "update",
    "level": "debug",
    "loop": "534",
    "message": "sent eviction to pod `kube-system/cert-exporter-deployment-65ccfdcfc-bls7d`",
    "object": "org-nick/ip-10-1-11-189.eu-west-1.compute.internal",
    "resource": "drainerv2",
    "time": "2022-12-06T10:24:57.459306+00:00",
    "version": "946287562"
}
```

We will fix the `cert-exporter-deployment` properly but unfortunately it would require a new release.

## Checklist

- [x] Update changelog in CHANGELOG.md.