### PR TITLE
Draining v2

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -15,3 +15,6 @@ CVE-2022-32149
 
 # Ignoring apiserver@v0.26.1
 sonatype-2022-6522 until=2023-06-25
+
+# Ignoring pkg:golang/golang.org/x/net@v0.5.0 (indirect dependency)
+CVE-2022-41723 until=2023-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Use Kubernetes Events on `AWSCluster` CR for draining status updates.
+- Concurrent execution of drainining to make sure the operator can handle multiple nodes going down for multiple clusters running in the same MC
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Use Kubernetes Events on `AWSCluster` CR for draining status updates.
+- Added the use the runtime/default seccomp profile.
 - Concurrent execution of drainining to make sure the operator can handle multiple nodes going down for multiple clusters running in the same MC
 
 ### Changed

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
-	v1alpha1 "github.com/giantswarm/node-operator/api"
 	"github.com/giantswarm/tenantcluster/v5/pkg/tenantcluster"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +18,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/drain"
+
+	v1alpha1 "github.com/giantswarm/node-operator/api"
 
 	"github.com/giantswarm/node-operator/service/controller/key"
 )

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -120,9 +120,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			Ctx:                             ctx,             // pass the current context
 			Client:                          k8sClient,       // the k8s client for making the API calls
 			Force:                           true,            // forcing the draining
-			GracePeriodSeconds:              30,              // 60 seconds of timeout before deleting the pod
+			GracePeriodSeconds:              60,              // 60 seconds of timeout before deleting the pod
 			IgnoreAllDaemonSets:             true,            // ignore the daemonsets
-			Timeout:                         1 * time.Minute, // give a 5 minutes timeout
+			Timeout:                         5 * time.Minute, // give a 5 minutes timeout
 			DeleteEmptyDirData:              true,            // delete all the emptyDir volumes
 			DisableEviction:                 false,           // we want to evict and not delete. (might be different for the master nodes)
 			SkipWaitForDeleteTimeoutSeconds: 15,              // in case a node is NotReady then the pods won't be deleted, so don't wait too long
@@ -152,6 +152,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			typeOfNode := "worker"
 			// In case of master nodes, just delete the pods, and don't evict them
 			if nodeIsMaster(&node) {
+
+				// 45 seconds pods termination grace period
+				nodeShutdownHelper.GracePeriodSeconds = 45
+
+				// 1 minute max timout since we are blocking here
+				nodeShutdownHelper.Timeout = 2 * time.Minute
 
 				// Set type to master
 				typeOfNode = "master"

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -193,7 +193,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 					// Otherwise try again to drain the node
 					draining <- drainingError
 
-					// Sebastian: I like the number 7 :D
+					// We need to pick a number here.
+					// Unfortunately there is no right amount of time to wait for the
+					// operation to complete. In various tests it seems a value
+					// between 10 and 5 is performing well. So picking the average and floring it
 				case <-time.After(7 * time.Second):
 					// we want to wait only for a max of N seconds, otherwise continue
 				}
@@ -324,7 +327,7 @@ func nodeIsMaster(node *v1.Node) bool {
 			return true
 		}
 
-		// Not sure where this comes from...
+		// Some master nodes seem to have this label
 		if key == "node.kubernetes.io/master" {
 			return true
 		}

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -329,33 +329,33 @@ func (r *Resource) drainNode(nodeName string,
 
 }
 
-// Drains a node in a blocking manner
-func (r *Resource) drainNodeBlocking(
-	nodeName string,
-	typeOfNode string,
-	ctx context.Context,
-	awsCluster infrastructurev1alpha3.AWSCluster,
-	shutdownHelper drain.Helper,
-	node v1.Node, k8sClient kubernetes.Interface,
-	drainerConfig v1alpha1.DrainerConfig) error {
+// // Drains a node in a blocking manner
+// func (r *Resource) drainNodeBlocking(
+// 	nodeName string,
+// 	typeOfNode string,
+// 	ctx context.Context,
+// 	awsCluster infrastructurev1alpha3.AWSCluster,
+// 	shutdownHelper drain.Helper,
+// 	node v1.Node, k8sClient kubernetes.Interface,
+// 	drainerConfig v1alpha1.DrainerConfig) error {
 
-	// Cordon the node
-	if err := r.cordon(ctx, awsCluster, shutdownHelper, node, typeOfNode); err != nil {
-		return err
-	}
+// 	// Cordon the node
+// 	if err := r.cordon(ctx, awsCluster, shutdownHelper, node, typeOfNode); err != nil {
+// 		return err
+// 	}
 
-	// Drain the node sync
-	err := r.drainNode(nodeName, typeOfNode, ctx, awsCluster, shutdownHelper, node, k8sClient, drainerConfig)
+// 	// Drain the node sync
+// 	err := r.drainNode(nodeName, typeOfNode, ctx, awsCluster, shutdownHelper, node, k8sClient, drainerConfig)
 
-	// In case of error mark the node in a timeout status so that it gets removed
-	if err != nil {
-		return r.updateDrainerStatus(ctx, drainerConfig.Status.NewTimeoutCondition(), drainerConfig, k8sClient)
-	}
+// 	// In case of error mark the node in a timeout status so that it gets removed
+// 	if err != nil {
+// 		return r.updateDrainerStatus(ctx, drainerConfig.Status.NewTimeoutCondition(), drainerConfig, k8sClient)
+// 	}
 
-	// In case of success mark the node as sucessfully drained
-	return r.updateDrainerStatus(ctx, drainerConfig.Status.NewDrainedCondition(), drainerConfig, k8sClient)
+// 	// In case of success mark the node as sucessfully drained
+// 	return r.updateDrainerStatus(ctx, drainerConfig.Status.NewDrainedCondition(), drainerConfig, k8sClient)
 
-}
+// }
 
 // Drain a node
 func (r *Resource) drainNodeAsync(

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -354,10 +354,15 @@ func (r *Resource) drainNodeAsync(
 // Checks whether a node is a master node
 func nodeIsMaster(node *v1.Node) bool {
 
-	for key := range node.Labels {
+	for key, value := range node.Labels {
 
 		// New label
 		if key == "node-role.kubernetes.io/control-plane" {
+			return true
+		}
+
+		// Not sure where this comes from...
+		if key == "node.kubernetes.io/master" {
 			return true
 		}
 
@@ -365,6 +370,11 @@ func nodeIsMaster(node *v1.Node) bool {
 		if key == "node-role.kubernetes.io/master" {
 			return true
 		}
+
+		if key == "role" && value == "master" {
+			return true
+		}
+
 	}
 
 	return false

--- a/service/controller/resource/drainer/delete.go
+++ b/service/controller/resource/drainer/delete.go
@@ -59,8 +59,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting tenant cluster node from Kubernetes API")
 
-		n := key.NodeNameFromDrainerConfig(drainerConfig)
-		err := k8sClient.CoreV1().Nodes().Delete(ctx, n, metav1.DeleteOptions{})
+		nodeName := key.NodeNameFromDrainerConfig(drainerConfig)
+
+		// make sure the entry in the state is removed
+		r.removeNodeFromState(nodeName)
+
+		err := k8sClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 		if tenant.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not delete tenant cluster node from Kubernetes API")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster API is not available")


### PR DESCRIPTION
This PR allows the node operator to execute the cordoning and draining of nodes concurrently.  
This is needed because the draining operation is blocking.  
So in case an MC is in the process of upgrading multiple clusters at the same time, we need to be able to, potentially, draining 10s of nodes concurrently.


## Checklist

- [x] Update changelog in CHANGELOG.md.
