### PR TITLE
Spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1] - 2023-03-02
+## [2.0.2] - 2023-03-02
 
 - Handling of Spot instances which have already been deleted from the cluster, but the DrainingConfigs are still present
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.1] - 2023-03-02
 
+- Handling of Spot instances which have already been deleted from the cluster, but the DrainingConfigs are still present
+
 ### Added
 
 - Use Kubernetes Events on `AWSCluster` CR for draining status updates.


### PR DESCRIPTION
Spot instance can actually be completely removed without notice.  
This causes the aws-operator however to still create DrainingConfigs.  
This PR addresses this case where the node-operator cannot find the v1.Node in the kubernetes state and therefore cannot cordon it and drain it, thus leaving an orphaned DrainingConfig.
## Checklist

- [x] Update changelog in CHANGELOG.md.
