### PR TITLE
Spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1] - 2023-03-02
+## [2.0.2] - 2023-03-02
 
 - Handling of Spot instances which have already been deleted from the cluster, but the DrainingConfigs are still present
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.1] - 2023-03-02
 
+- Handling of Spot instances which have already been deleted from the cluster, but the DrainingConfigs are still present
+
 ### Added
 
 - Use Kubernetes Events on `AWSCluster` CR for draining status updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.3] - 2023-03-02
 
+- Changed the DrainingConfig status to `Drained` instead of `Timeout`
+
 ## [2.0.2] - 2023-03-02
 
 - Handling of Spot instances which have already been deleted from the cluster, but the DrainingConfigs are still present

--- a/service/controller/resource/drainer/create.go
+++ b/service/controller/resource/drainer/create.go
@@ -225,8 +225,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		// if we get here it means we could not find the instance in the list of nodes
 		// this can happen for example if an instance is SPOT and therefore AWS just deletes it
-		r.logger.LogCtx(ctx, "level", "warn", "message", "Could not find the instance. Setting the draining status to: timed out")
-		return r.updateDrainerStatus(ctx, drainerConfig.Status.NewTimeoutCondition(), drainerConfig, k8sClient)
+		r.logger.LogCtx(ctx, "level", "warn", "message", "Could not find the instance. Setting the draining status to: drained")
+		return r.updateDrainerStatus(ctx, drainerConfig.Status.NewDrainedCondition(), drainerConfig, k8sClient)
 
 	}
 }


### PR DESCRIPTION
- Switched the DrainerConfig status to `Drained` instead of `Timeout` if a `v1.Node` is not found in Kubernetes


## Checklist

- [x] Update changelog in CHANGELOG.md.
