### PR TITLE
Add global.podSecurityStandards.enforced value for PSS migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add global.podSecurityStandards.enforced value for PSS migration.
+
 ### Changed
 
 - Configure `gsoci.azurecr.io` as the default container image registry.

--- a/helm/node-operator/templates/psp.yaml
+++ b/helm/node-operator/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/node-operator/templates/rbac.yaml
+++ b/helm/node-operator/templates/rbac.yaml
@@ -110,6 +110,7 @@ roleRef:
   name: {{ include "resource.default.name" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -140,3 +141,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/node-operator/values.schema.json
+++ b/helm/node-operator/values.schema.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/helm/node-operator/values.yaml
+++ b/helm/node-operator/values.yaml
@@ -47,3 +47,7 @@ serviceMonitor:
   interval: "60s"
   # -- (duration) Prometheus scrape timeout.
   scrapeTimeout: "45s"
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
Needed to upgrade vintage MCs to 1.25

## Checklist

- [x] Update changelog in CHANGELOG.md.
